### PR TITLE
Split paths and components on entry operations

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -28,6 +28,8 @@ import {
   userPath,
   usersPath,
   loginPath,
+  showEntryHistoryPath,
+  entryPath,
 } from "./Routes";
 import { Header } from "./components/Header";
 import { ACL } from "./pages/ACL";
@@ -51,6 +53,7 @@ import { Job } from "./pages/Job";
 import { Login } from "./pages/Login";
 import { Search } from "./pages/Search";
 import { ShowEntry } from "./pages/ShowEntry";
+import { ShowEntryHistory } from "./pages/ShowEntryHistory";
 import { User } from "./pages/User";
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -82,6 +85,11 @@ export const AppRouter: FC = () => {
               component={ImportEntry}
             />
             <Route
+              path={showEntryHistoryPath(":entryId")}
+              component={ShowEntryHistory}
+            />
+            <Route path={entryPath(":entryId")} component={EditEntry} />
+            <Route
               path={entityEntriesPath(":entityId")}
               component={EntryList}
             />
@@ -98,7 +106,7 @@ export const AppRouter: FC = () => {
             <Route path={groupPath(":groupId")} component={EditGroup} />
             <Route path={groupsPath()} component={Group} />
             <Route path={jobsPath()} component={Job} />
-            <Route path={aclPath(":entityId")} component={ACL} />
+            <Route path={aclPath(":objectId")} component={ACL} />
             <Route path={searchPath()} component={Search} />
             <Route path={newUserPath()} component={EditUser} />
             <Route path={importUsersPath()} component={ImportUser} />

--- a/frontend/src/Routes.ts
+++ b/frontend/src/Routes.ts
@@ -19,6 +19,10 @@ export const importEntriesPath = (entityId: number | string) =>
   basePath + `entities/${entityId}/entries/import`;
 export const entityEntriesPath = (entityId: number | string) =>
   basePath + `entities/${entityId}/entries`;
+export const showEntryHistoryPath = (entryId: number | string) =>
+  basePath + `entries/${entryId}/history`;
+export const entryPath = (entryId: number | string) =>
+  basePath + `entries/${entryId}`;
 
 // entities
 export const entityHistoryPath = (entityId: number | string) =>

--- a/frontend/src/components/entry/EntryList.tsx
+++ b/frontend/src/components/entry/EntryList.tsx
@@ -22,7 +22,13 @@ import { makeStyles } from "@mui/styles";
 import React, { FC, useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 
-import { aclPath, newEntryPath, showEntryPath } from "../../Routes";
+import {
+  aclPath,
+  entryPath,
+  newEntryPath,
+  showEntryHistoryPath,
+  showEntryPath,
+} from "../../Routes";
 import { deleteEntry, restoreEntry } from "../../utils/AironeAPIClient";
 import { EntryList as ConstEntryList } from "../../utils/Constants";
 
@@ -68,7 +74,7 @@ const EntryControlMenu: FC<EntryControlProps> = ({
       onClose={() => handleClose(entryId)}
       anchorEl={anchorElem}
     >
-      <MenuItem component={Link} to={showEntryPath(entryId)}>
+      <MenuItem component={Link} to={entryPath(entryId)}>
         <Typography>編集</Typography>
       </MenuItem>
       {/* have a confirmable component */}
@@ -82,7 +88,7 @@ const EntryControlMenu: FC<EntryControlProps> = ({
       </MenuItem>
       {/* This is a temporary configuration until
           Entry's history page will be divided from showing Page */}
-      <MenuItem component={Link} to={showEntryPath(entryId)}>
+      <MenuItem component={Link} to={showEntryHistoryPath(entryId)}>
         <Typography>変更履歴</Typography>
       </MenuItem>
     </Menu>

--- a/frontend/src/pages/ACL.tsx
+++ b/frontend/src/pages/ACL.tsx
@@ -10,10 +10,10 @@ import { Loading } from "../components/common/Loading";
 import { getACL } from "../utils/AironeAPIClient";
 
 export const ACL: FC = () => {
-  const { entityId } = useParams<{ entityId: number }>();
+  const { objectId } = useParams<{ objectId: number }>();
 
   const acl: any = useAsync(async () => {
-    const resp = await getACL(entityId);
+    const resp = await getACL(objectId);
     return await resp.json();
   });
 
@@ -31,7 +31,7 @@ export const ACL: FC = () => {
       ) : (
         <>
           <Typography>{acl.value.name} の ACL 設定</Typography>
-          <ACLForm objectId={entityId} acl={acl.value} />
+          <ACLForm objectId={objectId} acl={acl.value} />
         </>
       )}
     </Box>

--- a/frontend/src/pages/EditEntry.tsx
+++ b/frontend/src/pages/EditEntry.tsx
@@ -14,7 +14,8 @@ export const EditEntry: FC = () => {
 
   const entry: any = useAsync(async () => {
     if (entryId !== undefined) {
-      return await getEntry(entryId);
+      const resp = await getEntry(entryId);
+      return await resp.json();
     }
     return {};
   });
@@ -39,7 +40,7 @@ export const EditEntry: FC = () => {
           entityId={Number(entityId)}
           entryId={entry.value.id}
           initName={entry.value.name}
-          initAttributes={entry.value.attributes}
+          initAttributes={entry.value.attrs}
         />
       )}
     </Box>

--- a/frontend/src/pages/ShowEntryHistory.tsx
+++ b/frontend/src/pages/ShowEntryHistory.tsx
@@ -1,0 +1,21 @@
+import { Box } from "@mui/material";
+import React, { FC } from "react";
+import { useParams } from "react-router-dom";
+import { useAsync } from "react-use";
+
+import { EntryHistory } from "../components/entry/EntryHistory";
+import { getEntryHistory } from "../utils/AironeAPIClient";
+
+export const ShowEntryHistory: FC = () => {
+  const { entryId } = useParams<{ entityId: number }>();
+
+  const entryHistory: any = useAsync(async () => {
+    return await getEntryHistory(entryId);
+  });
+
+  return (
+    <Box>
+      {!entryHistory.loading && <EntryHistory histories={entryHistory.value} />}
+    </Box>
+  );
+};


### PR DESCRIPTION
Split and rearrange paths and components on entry operations, like editing entry, to navigate to each page from a new MenuItem.